### PR TITLE
feat: improved ssh support

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -8,3 +8,5 @@
 /dataSources.local.xml
 # Editor-based HTTP Client requests
 /httpRequests/
+
+copilotDiffState.xml

--- a/mossy-frontend/src/ui/passwords/PasswordEntryInput.tsx
+++ b/mossy-frontend/src/ui/passwords/PasswordEntryInput.tsx
@@ -1,9 +1,11 @@
-import { useState, type ChangeEvent } from 'react';
+import { useState } from 'react';
 import { MdCheck, MdClose, MdPassword, MdVpnKey } from 'react-icons/md';
 import type { PasswordFormState, SavePasswordResult } from './index.ts';
 import StrengthMeter from './StrengthMeter.tsx';
 import RippleButton from '../layout/RippleButton.tsx';
 import type { PasswordType } from '../../api/password.api.ts';
+import SshKeyEntryInput from './SshKeyEntryInput.tsx';
+import { validateSshKeyPair } from './secretPayload.ts';
 
 type PasswordEntryInputProps = {
 	initialState?: PasswordFormState;
@@ -48,45 +50,46 @@ export default function PasswordEntryInput({
 	const [formState, setFormState] = useState<PasswordFormState>(() => ({
 		...initialState,
 	}));
-	const [selectedFileName, setSelectedFileName] = useState('');
-	const [fileReadError, setFileReadError] = useState<string | null>(null);
+	const [submitError, setSubmitError] = useState<string | null>(null);
 	const [isSubmitPending, setIsSubmitPending] = useState(false);
 	const isBusy = isSubmitting || isSubmitPending;
 
-	const handleChange = (field: keyof PasswordFormState, value: string) => {
+	const handleBaseChange = (
+		field: 'identifier' | 'address',
+		value: string
+	) => {
 		setFormState((prev) => ({ ...prev, [field]: value }));
 	};
 
 	const handlePasswordTypeChange = (passwordType: PasswordType) => {
-		setSelectedFileName('');
-		setFileReadError(null);
-		setFormState((prev) => ({
-			...prev,
-			password: '',
-			passwordType,
-		}));
+		setSubmitError(null);
+		setFormState((prev) =>
+			passwordType === 'SSH_KEY'
+				? {
+						identifier: prev.identifier,
+						address: prev.address,
+						privateKey: '',
+						publicKey: '',
+						passwordType,
+					}
+				: {
+						identifier: prev.identifier,
+						address: prev.address,
+						password: '',
+						passwordType,
+					}
+		);
 	};
 
-	const handleSshKeyFileChange = async (
-		event: ChangeEvent<HTMLInputElement>
-	) => {
-		const file = event.target.files?.[0];
-		setFileReadError(null);
-
-		if (!file) {
-			setSelectedFileName('');
-			handleChange('password', '');
-			return;
-		}
-
-		setSelectedFileName(file.name);
-
-		try {
-			handleChange('password', await file.text());
-		} catch {
-			handleChange('password', '');
-			setFileReadError('Could not read selected file.');
-		}
+	const handlePasswordChange = (password: string) => {
+		setFormState((prev) =>
+			prev.passwordType === 'PASSWORD'
+				? {
+						...prev,
+						password,
+					}
+				: prev
+		);
 	};
 
 	return (
@@ -97,14 +100,19 @@ export default function PasswordEntryInput({
 				void (async () => {
 					if (isBusy) return;
 
-					if (
-						formState.passwordType === 'SSH_KEY' &&
-						!formState.password
-					) {
-						setFileReadError('Select an SSH key file first.');
-						return;
+					if (formState.passwordType === 'SSH_KEY') {
+						const validationMessage = validateSshKeyPair(
+							formState.privateKey,
+							formState.publicKey
+						);
+
+						if (validationMessage) {
+							setSubmitError(validationMessage);
+							return;
+						}
 					}
 
+					setSubmitError(null);
 					setIsSubmitPending(true);
 					let shouldClose = false;
 
@@ -187,7 +195,7 @@ export default function PasswordEntryInput({
 					name="identifier"
 					value={formState.identifier}
 					onChange={(event) =>
-						handleChange('identifier', event.target.value)
+						handleBaseChange('identifier', event.target.value)
 					}
 					placeholder="Enter identifier (email/username)"
 					className="border-b-2 p-2"
@@ -200,59 +208,42 @@ export default function PasswordEntryInput({
 					name="address"
 					value={formState.address}
 					onChange={(event) =>
-						handleChange('address', event.target.value)
+						handleBaseChange('address', event.target.value)
 					}
 					placeholder="Enter address"
 					className="border-b-2 p-2"
 					required
 				/>
-
-				<div className="flex flex-col gap-2 lg:col-span-2">
-					{formState.passwordType === 'SSH_KEY' ? (
-						<>
-							<input
-								type="file"
-								name="sshKey"
-								onChange={(event) => {
-									void handleSshKeyFileChange(event);
-								}}
-								className="border-b-2 p-2"
-								required={!formState.password}
-								accept=".pub,.pem,.ppk,.key,text/plain"
-							/>
-							{selectedFileName ? (
-								<p className="text-xs text-gray-500">
-									Selected {selectedFileName}
-								</p>
-							) : null}
-							{fileReadError ? (
-								<p className="text-xs text-red-600">
-									{fileReadError}
-								</p>
-							) : null}
-						</>
-					) : (
-						<>
-							<input
-								type="password"
-								name="password"
-								value={formState.password}
-								onChange={(event) =>
-									handleChange('password', event.target.value)
-								}
-								placeholder={
-									isEditing
-										? 'Enter new password'
-										: 'Enter password'
-								}
-								className="border-b-2 p-2"
-								required
-							/>
-							<StrengthMeter password={formState.password} />
-						</>
-					)}
-				</div>
 			</div>
+
+			{formState.passwordType === 'SSH_KEY' ? (
+				<SshKeyEntryInput
+					formState={formState}
+					setFormState={setFormState}
+					setSubmitError={setSubmitError}
+				/>
+			) : (
+				<div className="flex flex-col gap-2">
+					<input
+						type="password"
+						name="password"
+						value={formState.password}
+						onChange={(event) =>
+							handlePasswordChange(event.target.value)
+						}
+						placeholder={
+							isEditing ? 'Enter new password' : 'Enter password'
+						}
+						className="border-b-2 p-2"
+						required
+					/>
+					<StrengthMeter password={formState.password} />
+				</div>
+			)}
+
+			{submitError ? (
+				<p className="text-sm text-red-600">{submitError}</p>
+			) : null}
 
 			<div className="flex items-center gap-2">
 				<RippleButton

--- a/mossy-frontend/src/ui/passwords/PasswordHero.tsx
+++ b/mossy-frontend/src/ui/passwords/PasswordHero.tsx
@@ -1,54 +1,13 @@
-import { useEffect, useState } from 'react';
-import {
-	executeDeletePasswordRequest,
-	executePasswordCiphertextRequest,
-	executeSavePasswordRequest,
-	executeUpdatePasswordRequest,
-	type PasswordMetadataDto,
-	type ServerResponseDto,
-} from '../../api/password.api.ts';
+import { useEffect } from 'react';
 import { type UserVaultDto } from '../../api/vault.api.ts';
-import PasswordPinModal from '../shared/PasswordPinModal.tsx';
-import { useEncryptionHook } from '../../hooks/useEncryptionHook.ts';
 import VaultSelectorCard from './VaultSelectorCard.tsx';
-import type {
-	CiphertextPhase,
-	PasswordFormState,
-	SavePasswordResult,
-	StatusMessage,
-} from './index.ts';
 import PasswordListCard from './PasswordListCard.tsx';
 import { useVault } from '../../hooks/useVault.ts';
-import { KeyNotFoundException } from '../../exception/KeyNotFoundException.ts';
-import KeySyncModal from './KeySyncModal.tsx';
 import { useVaultStore } from '../../store/vaultStore.ts';
-import {
-	parseSecretPayload,
-	serializeSecretPayload,
-} from './secretPayload.ts';
 
 export default function PasswordHero() {
-	const { encrypt, decrypt, isPinPresent } = useEncryptionHook();
-
-	const [isPinModalActive, setIsPinModalActive] = useState(false);
-	const [isKeySyncModalActive, setIsKeySyncModalActive] = useState(false);
-	const [revealedPasswords, setRevealedPasswords] = useState<
-		Record<string, string>
-	>({});
 	const { selectedVaultId, setSelectedVaultId } = useVaultStore();
-
 	const { vaults, refreshVaults } = useVault();
-
-	const [isSubmitting, setIsSubmitting] = useState(false);
-	const [loadingCiphertextPhase, setLoadingCiphertextPhase] = useState<
-		Record<string, CiphertextPhase>
-	>({});
-	const [lastAction, setLastAction] = useState<
-		((pin: string) => void) | undefined
-	>();
-
-	const [status, setStatus] = useState<StatusMessage>(null);
-	const [passwordListRefreshToken, setPasswordListRefreshToken] = useState(0);
 
 	const selectedVault =
 		vaults.find((v) => v.vaultId === selectedVaultId) ?? null;
@@ -57,11 +16,6 @@ export default function PasswordHero() {
 		selectedVaultId && selectedVault?.isOnline
 	);
 
-	const resetPasswordView = () => {
-		setRevealedPasswords({});
-		setLoadingCiphertextPhase({});
-	};
-
 	useEffect(() => {
 		if (vaults.length === 0 || selectedVaultId) return;
 
@@ -69,350 +23,14 @@ export default function PasswordHero() {
 		if (!initial) return;
 
 		setSelectedVaultId(initial.vaultId);
-		resetPasswordView();
 	}, [vaults, selectedVaultId, setSelectedVaultId]);
-
-	useEffect(() => {
-		const bc = new BroadcastChannel('vault_updates');
-
-		bc.onmessage = (event) => {
-			if (event.data !== 'refresh' || !selectedVaultId) return;
-
-			const vault = vaults.find((v) => v.vaultId === selectedVaultId);
-			if (!vault?.isOnline) return;
-			setPasswordListRefreshToken((prev) => prev + 1);
-		};
-
-		return () => bc.close();
-	}, [selectedVaultId, vaults]);
-
-	const runWithVaultKeySync = async <T,>(
-		vaultId: string,
-		action: () => Promise<T>
-	): Promise<
-		| {
-				type: 'completed';
-				value: T;
-		  }
-		| { type: 'deferred' }
-	> => {
-		try {
-			if (!(await isPinPresent(vaultId))) {
-				setLastAction(() => () => {
-					void action();
-				});
-				setIsPinModalActive(true);
-				return { type: 'deferred' };
-			}
-		} catch (error) {
-			if (error instanceof KeyNotFoundException) {
-				setLastAction(() => () => {
-					void action();
-				});
-				setIsKeySyncModalActive(true);
-				return { type: 'deferred' };
-			}
-			throw error;
-		}
-
-		return { type: 'completed', value: await action() };
-	};
-
-	const resumeSavePassword = async (
-		formState: PasswordFormState,
-		passwordId?: string
-	): Promise<SavePasswordResult> => {
-		setIsSubmitting(true);
-		setStatus(null);
-
-		try {
-			const basePayload = {
-				identifier: formState.identifier,
-				address: formState.address,
-				cipherText: await encrypt(
-					serializeSecretPayload(formState),
-					selectedVaultId
-				),
-				vaultId: selectedVaultId,
-			};
-
-			const response: ServerResponseDto = passwordId
-				? await executeUpdatePasswordRequest({
-						...basePayload,
-						passwordId,
-					})
-				: await executeSavePasswordRequest({
-						...basePayload,
-						passwordType: formState.passwordType,
-					});
-
-			setStatus({ type: 'success', message: response.message });
-			await refreshVaults();
-			setPasswordListRefreshToken((prev) => prev + 1);
-			return 'saved';
-		} catch (error) {
-			setStatus({
-				type: 'error',
-				message:
-					error instanceof Error
-						? error.message
-						: 'Failed to save password data',
-			});
-			return 'failed';
-		} finally {
-			setIsSubmitting(false);
-		}
-	};
-
-	const getSshKeyFilename = (
-		password: PasswordMetadataDto,
-		keyType: 'private' | 'public'
-	) => {
-		const fallback = password.passwordId;
-		const rawName = password.identifier || password.address || fallback;
-		const safeName =
-			rawName
-				.trim()
-				.replace(/[^a-zA-Z0-9._-]+/g, '-')
-				.replace(/^-+|-+$/g, '') || fallback;
-
-		if (keyType === 'public') {
-			return safeName.endsWith('.pub') ? safeName : `${safeName}.pub`;
-		}
-
-		return safeName.endsWith('.key') || safeName.endsWith('.pem')
-			? safeName
-			: `${safeName}.key`;
-	};
-
-	const downloadTextFile = (filename: string, content: string) => {
-		const url = URL.createObjectURL(
-			new Blob([content], { type: 'application/octet-stream' })
-		);
-		const link = document.createElement('a');
-
-		link.href = url;
-		link.download = filename;
-		link.style.display = 'none';
-		document.body.appendChild(link);
-		link.click();
-		link.remove();
-		URL.revokeObjectURL(url);
-	};
-
-	const resumeRevealToggle = async (passwordId: string) => {
-		if (revealedPasswords[passwordId]) {
-			setRevealedPasswords((prev) => {
-				const next = { ...prev };
-				delete next[passwordId];
-				return next;
-			});
-			return;
-		}
-
-		setLoadingCiphertextPhase((prev) => ({
-			...prev,
-			[passwordId]: 'Fetching',
-		}));
-
-		setStatus(null);
-
-		try {
-			const response = await executePasswordCiphertextRequest(
-				passwordId,
-				selectedVaultId
-			);
-
-			setLoadingCiphertextPhase((prev) => ({
-				...prev,
-				[passwordId]: 'Decrypting',
-			}));
-
-			const decrypted = await decrypt(
-				response.ciphertext,
-				selectedVaultId
-			);
-			const secretPayload = parseSecretPayload(decrypted);
-
-			if (secretPayload.kind !== 'PASSWORD') {
-				throw new Error('Selected entry does not contain a password.');
-			}
-
-			setRevealedPasswords((prev) => ({
-				...prev,
-				[passwordId]: secretPayload.password,
-			}));
-		} catch (error) {
-			setStatus({
-				type: 'error',
-				message:
-					error instanceof Error
-						? error.message
-						: 'Failed to reveal password',
-			});
-		} finally {
-			setLoadingCiphertextPhase((prev) => {
-				const next = { ...prev };
-				delete next[passwordId];
-				return next;
-			});
-		}
-	};
-
-	const resumeDownloadSshKey = async (password: PasswordMetadataDto) => {
-		setLoadingCiphertextPhase((prev) => ({
-			...prev,
-			[password.passwordId]: 'Fetching',
-		}));
-
-		setStatus(null);
-
-		try {
-			const response = await executePasswordCiphertextRequest(
-				password.passwordId,
-				selectedVaultId
-			);
-
-			setLoadingCiphertextPhase((prev) => ({
-				...prev,
-				[password.passwordId]: 'Decrypting',
-			}));
-
-			const decrypted = await decrypt(
-				response.ciphertext,
-				selectedVaultId
-			);
-			const secretPayload = parseSecretPayload(decrypted);
-
-			if (secretPayload.kind !== 'SSH') {
-				throw new Error('Selected entry does not contain SSH keys.');
-			}
-
-			downloadTextFile(
-				getSshKeyFilename(password, 'private'),
-				secretPayload.privateKey
-			);
-			downloadTextFile(
-				getSshKeyFilename(password, 'public'),
-				secretPayload.publicKey
-			);
-		} catch (error) {
-			setStatus({
-				type: 'error',
-				message:
-					error instanceof Error
-						? error.message
-						: 'Failed to download SSH key',
-			});
-		} finally {
-			setLoadingCiphertextPhase((prev) => {
-				const next = { ...prev };
-				delete next[password.passwordId];
-				return next;
-			});
-		}
-	};
-
-	const handleSavePassword = async (
-		formState: PasswordFormState,
-		passwordId?: string
-	): Promise<SavePasswordResult> => {
-		if (!selectedVaultId || !selectedVault?.isOnline) {
-			setStatus({
-				type: 'error',
-				message: 'Select an online vault to save password',
-			});
-			return 'failed';
-		}
-
-		try {
-			const result = await runWithVaultKeySync(selectedVaultId, () =>
-				resumeSavePassword(formState, passwordId)
-			);
-
-			return result.type === 'deferred' ? 'deferred' : result.value;
-		} catch (error) {
-			setStatus({
-				type: 'error',
-				message:
-					error instanceof Error
-						? error.message
-						: 'Failed to save password data',
-			});
-			return 'failed';
-		}
-	};
-
-	const handleDelete = async (passwordId: string) => {
-		if (!selectedVaultId || !selectedVault?.isOnline) return;
-
-		setIsSubmitting(true);
-		setStatus(null);
-
-		try {
-			const response = await executeDeletePasswordRequest({
-				passwordId,
-				vaultId: selectedVaultId,
-			});
-
-			setStatus({ type: 'success', message: response.message });
-
-			await refreshVaults();
-			setPasswordListRefreshToken((prev) => prev + 1);
-		} catch (error) {
-			setStatus({
-				type: 'error',
-				message:
-					error instanceof Error
-						? error.message
-						: 'Failed to delete password',
-			});
-		} finally {
-			setIsSubmitting(false);
-		}
-	};
-
-	const handleRevealToggle = async (passwordId: string) => {
-		if (!selectedVaultId || !selectedVault?.isOnline) return;
-
-		await runWithVaultKeySync(selectedVaultId, () =>
-			resumeRevealToggle(passwordId)
-		);
-	};
-
-	const handleDownloadSshKey = async (password: PasswordMetadataDto) => {
-		if (!selectedVaultId || !selectedVault?.isOnline) return;
-
-		await runWithVaultKeySync(selectedVaultId, () =>
-			resumeDownloadSshKey(password)
-		);
-	};
 
 	const handleVaultSelect = async (vault: UserVaultDto) => {
 		setSelectedVaultId(vault.vaultId);
-		setStatus(null);
-		resetPasswordView();
-
-		if (!vault.isOnline) return;
 	};
 
 	return (
 		<section className="w-full p-5 flex flex-col gap-6">
-			{isPinModalActive && (
-				<PasswordPinModal
-					vaultId={selectedVaultId}
-					setIsPinModalActive={setIsPinModalActive}
-					afterPinEntered={lastAction}
-				/>
-			)}
-
-			{isKeySyncModalActive && (
-				<KeySyncModal
-					setIsKeySyncModalActive={setIsKeySyncModalActive}
-					vaultId={selectedVaultId}
-				/>
-			)}
-
 			<VaultSelectorCard
 				vaults={vaults}
 				selectedVaultId={selectedVaultId}
@@ -440,18 +58,8 @@ export default function PasswordHero() {
 				<div className="flex flex-col gap-6">
 					<PasswordListCard
 						vaultId={selectedVaultId}
-						refreshToken={passwordListRefreshToken}
-						revealedPasswords={revealedPasswords}
-						loadingCiphertextPhase={loadingCiphertextPhase}
-						isSubmitting={isSubmitting}
 						isVaultOnline={Boolean(selectedVault?.isOnline)}
-						status={status}
-						onSave={handleSavePassword}
-						onDelete={(id) => void handleDelete(id)}
-						onRevealToggle={(id) => void handleRevealToggle(id)}
-						onDownloadSshKey={(password) =>
-							void handleDownloadSshKey(password)
-						}
+						refreshVaults={refreshVaults}
 					/>
 				</div>
 			) : null}

--- a/mossy-frontend/src/ui/passwords/PasswordHero.tsx
+++ b/mossy-frontend/src/ui/passwords/PasswordHero.tsx
@@ -22,6 +22,10 @@ import { useVault } from '../../hooks/useVault.ts';
 import { KeyNotFoundException } from '../../exception/KeyNotFoundException.ts';
 import KeySyncModal from './KeySyncModal.tsx';
 import { useVaultStore } from '../../store/vaultStore.ts';
+import {
+	parseSecretPayload,
+	serializeSecretPayload,
+} from './secretPayload.ts';
 
 export default function PasswordHero() {
 	const { encrypt, decrypt, isPinPresent } = useEncryptionHook();
@@ -125,7 +129,10 @@ export default function PasswordHero() {
 			const basePayload = {
 				identifier: formState.identifier,
 				address: formState.address,
-				cipherText: await encrypt(formState.password, selectedVaultId),
+				cipherText: await encrypt(
+					serializeSecretPayload(formState),
+					selectedVaultId
+				),
 				vaultId: selectedVaultId,
 			};
 
@@ -157,7 +164,10 @@ export default function PasswordHero() {
 		}
 	};
 
-	const getSshKeyFilename = (password: PasswordMetadataDto) => {
+	const getSshKeyFilename = (
+		password: PasswordMetadataDto,
+		keyType: 'private' | 'public'
+	) => {
 		const fallback = password.passwordId;
 		const rawName = password.identifier || password.address || fallback;
 		const safeName =
@@ -165,6 +175,10 @@ export default function PasswordHero() {
 				.trim()
 				.replace(/[^a-zA-Z0-9._-]+/g, '-')
 				.replace(/^-+|-+$/g, '') || fallback;
+
+		if (keyType === 'public') {
+			return safeName.endsWith('.pub') ? safeName : `${safeName}.pub`;
+		}
 
 		return safeName.endsWith('.key') || safeName.endsWith('.pem')
 			? safeName
@@ -218,10 +232,15 @@ export default function PasswordHero() {
 				response.ciphertext,
 				selectedVaultId
 			);
+			const secretPayload = parseSecretPayload(decrypted);
+
+			if (secretPayload.kind !== 'PASSWORD') {
+				throw new Error('Selected entry does not contain a password.');
+			}
 
 			setRevealedPasswords((prev) => ({
 				...prev,
-				[passwordId]: decrypted,
+				[passwordId]: secretPayload.password,
 			}));
 		} catch (error) {
 			setStatus({
@@ -263,8 +282,20 @@ export default function PasswordHero() {
 				response.ciphertext,
 				selectedVaultId
 			);
+			const secretPayload = parseSecretPayload(decrypted);
 
-			downloadTextFile(getSshKeyFilename(password), decrypted);
+			if (secretPayload.kind !== 'SSH') {
+				throw new Error('Selected entry does not contain SSH keys.');
+			}
+
+			downloadTextFile(
+				getSshKeyFilename(password, 'private'),
+				secretPayload.privateKey
+			);
+			downloadTextFile(
+				getSshKeyFilename(password, 'public'),
+				secretPayload.publicKey
+			);
 		} catch (error) {
 			setStatus({
 				type: 'error',

--- a/mossy-frontend/src/ui/passwords/PasswordListCard.tsx
+++ b/mossy-frontend/src/ui/passwords/PasswordListCard.tsx
@@ -2,8 +2,8 @@ import {
 	executePasswordMetadataRequest,
 	type PasswordMetadataDto,
 } from '../../api/password.api.ts';
-import type { CiphertextPhase } from './index.ts';
 import PasswordListItem from './PasswordListItem.tsx';
+import SshKeyListItem from './SshKeyListItem.tsx';
 import TagsMenu from './tag/TagsMenu.tsx';
 import { useSearchStore } from '../../store/searchStore.ts';
 import { useEffect, useMemo, useState } from 'react';
@@ -11,43 +11,36 @@ import Fuse from 'fuse.js';
 import SearchBar from './SearchBar.tsx';
 import { MdAdd } from 'react-icons/md';
 import PasswordEntryInput from './PasswordEntryInput.tsx';
-import type {
-	PasswordFormState,
-	SavePasswordResult,
-	StatusMessage,
-} from './index.ts';
+import { usePasswordListActions } from './usePasswordListActions.tsx';
 
 type PasswordListCardProps = {
 	vaultId: string;
-	refreshToken: number;
-	revealedPasswords: Record<string, string>;
-	loadingCiphertextPhase: Record<string, CiphertextPhase>;
-	isSubmitting: boolean;
 	isVaultOnline: boolean;
-	status: StatusMessage;
-	onSave: (
-		formState: PasswordFormState,
-		passwordId?: string
-	) => Promise<SavePasswordResult>;
-	onDelete: (passwordId: string) => void;
-	onRevealToggle: (passwordId: string) => void;
-	onDownloadSshKey: (password: PasswordMetadataDto) => void;
+	refreshVaults: () => Promise<void>;
 };
 
 function PasswordListCard({
 	vaultId,
-	refreshToken,
-	revealedPasswords,
-	loadingCiphertextPhase,
-	isSubmitting,
 	isVaultOnline,
-	status,
-	onSave,
-	onDelete,
-	onRevealToggle,
-	onDownloadSshKey,
+	refreshVaults,
 }: PasswordListCardProps) {
 	const { query, selectedTagsId } = useSearchStore();
+	const {
+		isSubmitting,
+		status,
+		refreshToken,
+		revealedPasswords,
+		loadingCiphertextPhase,
+		handleSavePassword,
+		handleDelete,
+		handleRevealToggle,
+		handleDownloadSshKey,
+		actionModals,
+	} = usePasswordListActions({
+		vaultId,
+		isVaultOnline,
+		refreshVaults,
+	});
 
 	const [passwords, setPasswords] = useState<PasswordMetadataDto[]>([]);
 	const [isLoadingPasswords, setIsLoadingPasswords] = useState(false);
@@ -60,6 +53,10 @@ function PasswordListCard({
 		}
 		void loadPasswords(vaultId);
 	}, [vaultId, refreshToken]);
+
+	useEffect(() => {
+		setIsAddingPassword(false);
+	}, [vaultId]);
 
 	const loadPasswords = async (id: string) => {
 		setIsLoadingPasswords(true);
@@ -105,6 +102,8 @@ function PasswordListCard({
 
 	return (
 		<section className="rounded-md bg-white p-5 shadow-md w-full">
+			{actionModals}
+
 			<div
 				className={
 					'flex flex-wrap justify-between items-center w-full gap-3 relative mb-4'
@@ -152,7 +151,11 @@ function PasswordListCard({
 					<PasswordEntryInput
 						isSubmitting={isSubmitting}
 						isVaultOnline={isVaultOnline}
-						onSubmit={onSave}
+						onSubmit={(formState) =>
+							handleSavePassword(formState, undefined, {
+								onSaved: () => setIsAddingPassword(false),
+							})
+						}
 						onCancel={() => setIsAddingPassword(false)}
 					/>
 				</div>
@@ -161,27 +164,48 @@ function PasswordListCard({
 			<div className="flex max-h-[60vh] flex-col gap-3 overflow-y-auto pr-1 mt-5">
 				{!isLoadingPasswords ? (
 					results.length > 0 ? (
-						results.map((result) => (
-							<PasswordListItem
-								key={result.item.passwordId}
-								passwordDto={result.item}
-								setPasswordDto={setPasswords}
-								revealedPassword={
-									revealedPasswords[result.item.passwordId]
-								}
-								phase={
-									loadingCiphertextPhase[
-										result.item.passwordId
-									]
-								}
-								isSubmitting={isSubmitting}
-								isVaultOnline={isVaultOnline}
-								onSave={onSave}
-								onDelete={onDelete}
-								onRevealToggle={onRevealToggle}
-								onDownloadSshKey={onDownloadSshKey}
-							/>
-						))
+						results.map((result) => {
+							const password = result.item;
+							const phase =
+								loadingCiphertextPhase[password.passwordId];
+
+							if (password.passwordType === 'SSH_KEY') {
+								return (
+									<SshKeyListItem
+										key={password.passwordId}
+										passwordDto={password}
+										setPasswordDto={setPasswords}
+										phase={phase}
+										isSubmitting={isSubmitting}
+										isVaultOnline={isVaultOnline}
+										onSave={handleSavePassword}
+										onDelete={(id) => void handleDelete(id)}
+										onDownloadSshKey={(password) =>
+											void handleDownloadSshKey(password)
+										}
+									/>
+								);
+							}
+
+							return (
+								<PasswordListItem
+									key={password.passwordId}
+									passwordDto={password}
+									setPasswordDto={setPasswords}
+									revealedPassword={
+										revealedPasswords[password.passwordId]
+									}
+									phase={phase}
+									isSubmitting={isSubmitting}
+									isVaultOnline={isVaultOnline}
+									onSave={handleSavePassword}
+									onDelete={(id) => void handleDelete(id)}
+									onRevealToggle={(id) =>
+										void handleRevealToggle(id)
+									}
+								/>
+							);
+						})
 					) : (
 						<p className={'text-sm text-gray-500'}>
 							{query || selectedTagsId.length > 0

--- a/mossy-frontend/src/ui/passwords/PasswordListItem.tsx
+++ b/mossy-frontend/src/ui/passwords/PasswordListItem.tsx
@@ -1,25 +1,13 @@
-import { useMemo, useState } from 'react';
-import {
-	type PasswordMetadataDto,
-	type TagDto,
-} from '../../api/password.api.ts';
-import type { CiphertextPhase } from './index.ts';
-import RippleButton from '../layout/RippleButton.tsx';
-import Tag from './tag/Tag.tsx';
-import AssignTagDropdown from './tag/AssignTagDropdown.tsx';
 import * as React from 'react';
-import NoteCard from './note/NoteCard.tsx';
-import {
-	MdDownload,
-	MdDelete,
-	MdEdit,
-	MdOutlineStickyNote2,
-	MdPassword,
-	MdStickyNote2,
-	MdVpnKey,
-} from 'react-icons/md';
-import PasswordEntryInput from './PasswordEntryInput.tsx';
-import type { PasswordFormState, SavePasswordResult } from './index.ts';
+import { MdPassword } from 'react-icons/md';
+import type { PasswordMetadataDto } from '../../api/password.api.ts';
+import type {
+	CiphertextPhase,
+	PasswordFormState,
+	SavePasswordResult,
+} from './index.ts';
+import RippleButton from '../layout/RippleButton.tsx';
+import PasswordListItemFrame from './PasswordListItemFrame.tsx';
 
 type PasswordListItemProps = {
 	passwordDto: PasswordMetadataDto;
@@ -34,7 +22,6 @@ type PasswordListItemProps = {
 	) => Promise<SavePasswordResult>;
 	onDelete: (passwordId: string) => void;
 	onRevealToggle: (passwordId: string) => void;
-	onDownloadSshKey: (password: PasswordMetadataDto) => void;
 };
 
 function PasswordListItem({
@@ -47,208 +34,45 @@ function PasswordListItem({
 	onSave,
 	onDelete,
 	onRevealToggle,
-	onDownloadSshKey,
 }: PasswordListItemProps) {
-	const assignedTags = useMemo(() => passwordDto.tags, [passwordDto.tags]);
-	const [isNoteShown, setIsNoteShown] = useState(false);
-	const [isEditing, setIsEditing] = useState(false);
-
-	const setAssignedTags: React.Dispatch<React.SetStateAction<TagDto[]>> = (
-		value
-	) => {
-		setPasswordDto((prev) =>
-			prev.map((password) => {
-				if (password.passwordId !== passwordDto.passwordId) {
-					return password;
-				}
-
-				const tags =
-					typeof value === 'function' ? value(password.tags) : value;
-
-				return {
-					...password,
-					tags,
-				};
-			})
-		);
-	};
-
-	if (isEditing) {
-		const initialState: PasswordFormState =
-			passwordDto.passwordType === 'SSH_KEY'
-				? {
-						identifier: passwordDto.identifier,
-						address: passwordDto.address,
-						privateKey: '',
-						publicKey: '',
-						passwordType: 'SSH_KEY',
-					}
-				: {
-						identifier: passwordDto.identifier,
-						address: passwordDto.address,
-						password: '',
-						passwordType: 'PASSWORD',
-					};
-
-		return (
-			<PasswordEntryInput
-				initialState={initialState}
-				isEditing
-				isSubmitting={isSubmitting}
-				isVaultOnline={isVaultOnline}
-				onSubmit={(formState) =>
-					onSave(formState, passwordDto.passwordId)
-				}
-				onCancel={() => setIsEditing(false)}
-			/>
-		);
-	}
-
 	return (
-		<article className="flex flex-col gap-3 rounded-md border border-gray-200 p-3">
-			<div className="flex items-start justify-between gap-3">
-				<div>
-					<div className="flex items-center gap-2">
-						<span
-							className="inline-flex h-5 w-5 items-center justify-center rounded-sm bg-gray-100 text-gray-700"
-							title={
-								passwordDto.passwordType === 'SSH_KEY'
-									? 'SSH key'
-									: 'Password'
-							}
-							aria-label={
-								passwordDto.passwordType === 'SSH_KEY'
-									? 'SSH key'
-									: 'Password'
-							}
-						>
-							{passwordDto.passwordType === 'SSH_KEY' ? (
-								<MdVpnKey size={14} />
-							) : (
-								<MdPassword size={14} />
-							)}
-						</span>
-
-						<p className="font-medium text-gray-900">
-							{passwordDto.identifier}
-						</p>
-					</div>
-
-					<p className="text-sm text-gray-600">
-						{passwordDto.address}
-					</p>
-
-					<p className="text-xs text-gray-500">
-						Updated{' '}
-						{new Date(passwordDto.lastModified).toLocaleString()}
-					</p>
-
-					<div className="flex flex-wrap gap-1 mt-2">
-						{assignedTags.length > 0 ? (
-							assignedTags.map((tag) => (
-								<Tag
-									key={tag.tagId}
-									tagId={tag.tagId}
-									name={tag.tagName}
-									color={tag.color}
-								/>
-							))
-						) : (
-							<Tag name="unlabeled" color="#373737" />
-						)}
-
-						<AssignTagDropdown
-							assignedTags={assignedTags}
-							setAssignedTags={setAssignedTags}
-							passwordId={passwordDto.passwordId}
-						/>
-					</div>
-				</div>
-
-				<div className={'flex flex-col items-end gap-2'}>
-					<div className="flex gap-2">
-						<button
-							type="button"
-							className="inline-flex h-8 w-8 items-center justify-center rounded-sm border text-gray-700 hover:bg-gray-50 disabled:opacity-60"
-							disabled={isSubmitting}
-							onClick={() => setIsEditing(true)}
-							aria-label="Edit password"
-							title="Edit password"
-						>
-							<MdEdit size={18} />
-						</button>
-
-						<button
-							type="button"
-							className="inline-flex h-8 w-8 items-center justify-center rounded-sm border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-60"
-							disabled={isSubmitting}
-							onClick={() => onDelete(passwordDto.passwordId)}
-							aria-label="Delete password"
-							title="Delete password"
-						>
-							<MdDelete size={18} />
-						</button>
-					</div>
-
-					{passwordDto.hasNote ? (
-						<MdStickyNote2
-							size={32}
-							className={`cursor-pointer`}
-							onClick={() => setIsNoteShown(!isNoteShown)}
-						/>
-					) : (
-						<MdOutlineStickyNote2
-							size={32}
-							className={`cursor-pointer`}
-							onClick={() => setIsNoteShown(!isNoteShown)}
-						/>
-					)}
-				</div>
-			</div>
-
-			<NoteCard
-				isOpen={isNoteShown}
-				setIsOpen={setIsNoteShown}
-				passwordId={passwordDto.passwordId}
-			/>
-
+		<PasswordListItemFrame
+			passwordDto={passwordDto}
+			setPasswordDto={setPasswordDto}
+			isSubmitting={isSubmitting}
+			isVaultOnline={isVaultOnline}
+			onSave={onSave}
+			onDelete={onDelete}
+			icon={<MdPassword size={14} />}
+			iconLabel="Password"
+			editInitialState={{
+				identifier: passwordDto.identifier,
+				address: passwordDto.address,
+				password: '',
+				passwordType: 'PASSWORD',
+			}}
+		>
 			<div className="flex items-center justify-between gap-3 rounded bg-gray-50 p-2">
 				<p className="max-w-full overflow-x-auto whitespace-nowrap font-mono text-sm text-gray-700">
-					{passwordDto.passwordType === 'SSH_KEY'
-						? 'SSH key file'
-						: (revealedPassword ?? '••••••••••••')}
+					{revealedPassword ?? '••••••••••••'}
 				</p>
 
-				{passwordDto.passwordType === 'SSH_KEY' ? (
-					<RippleButton
-						type="button"
-						variant="outline"
-						className="inline-flex items-center gap-1 rounded-sm border px-2 py-1 text-sm"
-						disabled={phase !== undefined}
-						rippleColor="rgb(0, 0, 0, 0.7)"
-						onClick={() => onDownloadSshKey(passwordDto)}
-					>
-						<MdDownload size={16} />
-						{phase !== undefined ? `${phase}...` : 'Download keys'}
-					</RippleButton>
-				) : (
-					<RippleButton
-						type="button"
-						variant="outline"
-						className="rounded-sm border px-2 py-1 text-sm"
-						disabled={phase !== undefined}
-						rippleColor="rgb(0, 0, 0, 0.7)"
-						onClick={() => onRevealToggle(passwordDto.passwordId)}
-					>
-						{phase !== undefined
-							? `${phase}...`
-							: revealedPassword
-								? 'Hide'
-								: 'Reveal'}
-					</RippleButton>
-				)}
+				<RippleButton
+					type="button"
+					variant="outline"
+					className="rounded-sm border px-2 py-1 text-sm"
+					disabled={phase !== undefined}
+					rippleColor="rgb(0, 0, 0, 0.7)"
+					onClick={() => onRevealToggle(passwordDto.passwordId)}
+				>
+					{phase !== undefined
+						? `${phase}...`
+						: revealedPassword
+							? 'Hide'
+							: 'Reveal'}
+				</RippleButton>
 			</div>
-		</article>
+		</PasswordListItemFrame>
 	);
 }
 

--- a/mossy-frontend/src/ui/passwords/PasswordListItem.tsx
+++ b/mossy-frontend/src/ui/passwords/PasswordListItem.tsx
@@ -74,14 +74,25 @@ function PasswordListItem({
 	};
 
 	if (isEditing) {
+		const initialState: PasswordFormState =
+			passwordDto.passwordType === 'SSH_KEY'
+				? {
+						identifier: passwordDto.identifier,
+						address: passwordDto.address,
+						privateKey: '',
+						publicKey: '',
+						passwordType: 'SSH_KEY',
+					}
+				: {
+						identifier: passwordDto.identifier,
+						address: passwordDto.address,
+						password: '',
+						passwordType: 'PASSWORD',
+					};
+
 		return (
 			<PasswordEntryInput
-				initialState={{
-					identifier: passwordDto.identifier,
-					address: passwordDto.address,
-					password: '',
-					passwordType: passwordDto.passwordType,
-				}}
+				initialState={initialState}
 				isEditing
 				isSubmitting={isSubmitting}
 				isVaultOnline={isVaultOnline}
@@ -218,7 +229,7 @@ function PasswordListItem({
 						onClick={() => onDownloadSshKey(passwordDto)}
 					>
 						<MdDownload size={16} />
-						{phase !== undefined ? `${phase}...` : 'Download'}
+						{phase !== undefined ? `${phase}...` : 'Download keys'}
 					</RippleButton>
 				) : (
 					<RippleButton

--- a/mossy-frontend/src/ui/passwords/PasswordListItemFrame.tsx
+++ b/mossy-frontend/src/ui/passwords/PasswordListItemFrame.tsx
@@ -1,0 +1,185 @@
+import { useMemo, useState } from 'react';
+import * as React from 'react';
+import {
+	type PasswordMetadataDto,
+	type TagDto,
+} from '../../api/password.api.ts';
+import type { PasswordFormState, SavePasswordResult } from './index.ts';
+import PasswordEntryInput from './PasswordEntryInput.tsx';
+import Tag from './tag/Tag.tsx';
+import AssignTagDropdown from './tag/AssignTagDropdown.tsx';
+import NoteCard from './note/NoteCard.tsx';
+import {
+	MdDelete,
+	MdEdit,
+	MdOutlineStickyNote2,
+	MdStickyNote2,
+} from 'react-icons/md';
+
+export type PasswordListItemFrameProps = {
+	passwordDto: PasswordMetadataDto;
+	setPasswordDto: React.Dispatch<React.SetStateAction<PasswordMetadataDto[]>>;
+	isSubmitting: boolean;
+	isVaultOnline: boolean;
+	onSave: (
+		formState: PasswordFormState,
+		passwordId?: string
+	) => Promise<SavePasswordResult>;
+	onDelete: (passwordId: string) => void;
+	icon: React.ReactNode;
+	iconLabel: string;
+	editInitialState: PasswordFormState;
+	children: React.ReactNode;
+};
+
+export default function PasswordListItemFrame({
+	passwordDto,
+	setPasswordDto,
+	isSubmitting,
+	isVaultOnline,
+	onSave,
+	onDelete,
+	icon,
+	iconLabel,
+	editInitialState,
+	children,
+}: PasswordListItemFrameProps) {
+	const assignedTags = useMemo(() => passwordDto.tags, [passwordDto.tags]);
+	const [isNoteShown, setIsNoteShown] = useState(false);
+	const [isEditing, setIsEditing] = useState(false);
+
+	const setAssignedTags: React.Dispatch<React.SetStateAction<TagDto[]>> = (
+		value
+	) => {
+		setPasswordDto((prev) =>
+			prev.map((password) => {
+				if (password.passwordId !== passwordDto.passwordId) {
+					return password;
+				}
+
+				const tags =
+					typeof value === 'function' ? value(password.tags) : value;
+
+				return {
+					...password,
+					tags,
+				};
+			})
+		);
+	};
+
+	if (isEditing) {
+		return (
+			<PasswordEntryInput
+				initialState={editInitialState}
+				isEditing
+				isSubmitting={isSubmitting}
+				isVaultOnline={isVaultOnline}
+				onSubmit={(formState) =>
+					onSave(formState, passwordDto.passwordId)
+				}
+				onCancel={() => setIsEditing(false)}
+			/>
+		);
+	}
+
+	return (
+		<article className="flex flex-col gap-3 rounded-md border border-gray-200 p-3">
+			<div className="flex items-start justify-between gap-3">
+				<div>
+					<div className="flex items-center gap-2">
+						<span
+							className="inline-flex h-5 w-5 items-center justify-center rounded-sm bg-gray-100 text-gray-700"
+							title={iconLabel}
+							aria-label={iconLabel}
+						>
+							{icon}
+						</span>
+
+						<p className="font-medium text-gray-900">
+							{passwordDto.identifier}
+						</p>
+					</div>
+
+					<p className="text-sm text-gray-600">
+						{passwordDto.address}
+					</p>
+
+					<p className="text-xs text-gray-500">
+						Updated{' '}
+						{new Date(passwordDto.lastModified).toLocaleString()}
+					</p>
+
+					<div className="flex flex-wrap gap-1 mt-2">
+						{assignedTags.length > 0 ? (
+							assignedTags.map((tag) => (
+								<Tag
+									key={tag.tagId}
+									tagId={tag.tagId}
+									name={tag.tagName}
+									color={tag.color}
+								/>
+							))
+						) : (
+							<Tag name="unlabeled" color="#373737" />
+						)}
+
+						<AssignTagDropdown
+							assignedTags={assignedTags}
+							setAssignedTags={setAssignedTags}
+							passwordId={passwordDto.passwordId}
+						/>
+					</div>
+				</div>
+
+				<div className="flex flex-col items-end gap-2">
+					<div className="flex gap-2">
+						<button
+							type="button"
+							className="inline-flex h-8 w-8 items-center justify-center rounded-sm border text-gray-700 hover:bg-gray-50 disabled:opacity-60"
+							disabled={isSubmitting}
+							onClick={() => setIsEditing(true)}
+							aria-label={`Edit ${iconLabel.toLowerCase()}`}
+							title={`Edit ${iconLabel.toLowerCase()}`}
+						>
+							<MdEdit size={18} />
+						</button>
+
+						<button
+							type="button"
+							className="inline-flex h-8 w-8 items-center justify-center rounded-sm border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-60"
+							disabled={isSubmitting}
+							onClick={() => onDelete(passwordDto.passwordId)}
+							aria-label={`Delete ${iconLabel.toLowerCase()}`}
+							title={`Delete ${iconLabel.toLowerCase()}`}
+						>
+							<MdDelete size={18} />
+						</button>
+					</div>
+
+					{passwordDto.hasNote ? (
+						<MdStickyNote2
+							size={32}
+							className="cursor-pointer"
+							onClick={() => setIsNoteShown(!isNoteShown)}
+						/>
+					) : (
+						<MdOutlineStickyNote2
+							size={32}
+							className="cursor-pointer"
+							onClick={() => setIsNoteShown(!isNoteShown)}
+						/>
+					)}
+				</div>
+			</div>
+
+			<NoteCard
+				isOpen={isNoteShown}
+				setIsOpen={setIsNoteShown}
+				passwordId={passwordDto.passwordId}
+			/>
+
+			{children}
+		</article>
+	);
+}

--- a/mossy-frontend/src/ui/passwords/SshKeyEntryInput.tsx
+++ b/mossy-frontend/src/ui/passwords/SshKeyEntryInput.tsx
@@ -1,0 +1,134 @@
+import {
+	useMemo,
+	type ChangeEvent,
+	type Dispatch,
+	type SetStateAction,
+} from 'react';
+import { MdErrorOutline, MdUploadFile } from 'react-icons/md';
+import type { PasswordFormState } from './index.ts';
+import { validateSshKeyPair } from './secretPayload.ts';
+
+type SshPasswordFormState = Extract<
+	PasswordFormState,
+	{ passwordType: 'SSH_KEY' }
+>;
+
+type SshKeyEntryInputProps = {
+	formState: SshPasswordFormState;
+	setFormState: Dispatch<SetStateAction<PasswordFormState>>;
+	setSubmitError: (value: string | null) => void;
+};
+
+async function readFileText(event: ChangeEvent<HTMLInputElement>) {
+	const file = event.target.files?.[0];
+
+	if (!file) return null;
+
+	return {
+		name: file.name,
+		content: await file.text(),
+	};
+}
+
+export default function SshKeyEntryInput({
+	formState,
+	setFormState,
+	setSubmitError,
+}: SshKeyEntryInputProps) {
+	const validationMessage = useMemo(
+		() => validateSshKeyPair(formState.privateKey, formState.publicKey),
+		[formState.privateKey, formState.publicKey]
+	);
+
+	const updateField = (
+		field: 'privateKey' | 'publicKey',
+		value: string
+	) => {
+		setSubmitError(null);
+		setFormState((prev) =>
+			prev.passwordType === 'SSH_KEY'
+				? {
+						...prev,
+						[field]: value,
+					}
+				: prev
+		);
+	};
+
+	const handleFile = async (
+		field: 'privateKey' | 'publicKey',
+		event: ChangeEvent<HTMLInputElement>
+	) => {
+		setSubmitError(null);
+
+		try {
+			const file = await readFileText(event);
+			if (!file) return;
+
+			updateField(field, file.content);
+		} catch {
+			setSubmitError('Could not read selected SSH key file.');
+		}
+	};
+
+	return (
+		<div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+			<label className="flex min-h-56 flex-col gap-2 rounded-sm border border-gray-200 p-3">
+				<span className="text-sm font-medium text-gray-700">
+					Private key
+				</span>
+				<textarea
+					name="privateKey"
+					value={formState.privateKey}
+					onChange={(event) =>
+						updateField('privateKey', event.target.value)
+					}
+					className="min-h-40 flex-1 resize-y border-0 bg-gray-50 p-2 font-mono text-sm outline-none focus:ring-2 focus:ring-emerald-700"
+					required
+					spellCheck={false}
+				/>
+				<span className="inline-flex items-center gap-2 text-sm text-gray-600">
+					<MdUploadFile size={16} />
+					<input
+						type="file"
+						accept=".pem,.ppk,.key,text/plain"
+						onChange={(event) => void handleFile('privateKey', event)}
+						className="text-sm"
+					/>
+				</span>
+			</label>
+
+			<label className="flex min-h-56 flex-col gap-2 rounded-sm border border-gray-200 p-3">
+				<span className="text-sm font-medium text-gray-700">
+					Public key
+				</span>
+				<textarea
+					name="publicKey"
+					value={formState.publicKey}
+					onChange={(event) =>
+						updateField('publicKey', event.target.value)
+					}
+					className="min-h-40 flex-1 resize-y border-0 bg-gray-50 p-2 font-mono text-sm outline-none focus:ring-2 focus:ring-emerald-700"
+					required
+					spellCheck={false}
+				/>
+				<span className="inline-flex items-center gap-2 text-sm text-gray-600">
+					<MdUploadFile size={16} />
+					<input
+						type="file"
+						accept=".pub,text/plain"
+						onChange={(event) => void handleFile('publicKey', event)}
+						className="text-sm"
+					/>
+				</span>
+			</label>
+
+			{validationMessage ? (
+				<p className="inline-flex items-center gap-1 text-sm text-red-600 lg:col-span-2">
+					<MdErrorOutline size={16} />
+					{validationMessage}
+				</p>
+			) : null}
+		</div>
+	);
+}

--- a/mossy-frontend/src/ui/passwords/SshKeyEntryInput.tsx
+++ b/mossy-frontend/src/ui/passwords/SshKeyEntryInput.tsx
@@ -40,10 +40,7 @@ export default function SshKeyEntryInput({
 		[formState.privateKey, formState.publicKey]
 	);
 
-	const updateField = (
-		field: 'privateKey' | 'publicKey',
-		value: string
-	) => {
+	const updateField = (field: 'privateKey' | 'publicKey', value: string) => {
 		setSubmitError(null);
 		setFormState((prev) =>
 			prev.passwordType === 'SSH_KEY'
@@ -75,7 +72,7 @@ export default function SshKeyEntryInput({
 		<div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
 			<label className="flex min-h-56 flex-col gap-2 rounded-sm border border-gray-200 p-3">
 				<span className="text-sm font-medium text-gray-700">
-					Private key
+					Private key <span className="text-red-500">*</span>
 				</span>
 				<textarea
 					name="privateKey"
@@ -92,7 +89,9 @@ export default function SshKeyEntryInput({
 					<input
 						type="file"
 						accept=".pem,.ppk,.key,text/plain"
-						onChange={(event) => void handleFile('privateKey', event)}
+						onChange={(event) =>
+							void handleFile('privateKey', event)
+						}
 						className="text-sm"
 					/>
 				</span>
@@ -109,7 +108,6 @@ export default function SshKeyEntryInput({
 						updateField('publicKey', event.target.value)
 					}
 					className="min-h-40 flex-1 resize-y border-0 bg-gray-50 p-2 font-mono text-sm outline-none focus:ring-2 focus:ring-emerald-700"
-					required
 					spellCheck={false}
 				/>
 				<span className="inline-flex items-center gap-2 text-sm text-gray-600">
@@ -117,7 +115,9 @@ export default function SshKeyEntryInput({
 					<input
 						type="file"
 						accept=".pub,text/plain"
-						onChange={(event) => void handleFile('publicKey', event)}
+						onChange={(event) =>
+							void handleFile('publicKey', event)
+						}
 						className="text-sm"
 					/>
 				</span>

--- a/mossy-frontend/src/ui/passwords/SshKeyListItem.tsx
+++ b/mossy-frontend/src/ui/passwords/SshKeyListItem.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { MdDownload, MdVpnKey } from 'react-icons/md';
+import type { PasswordMetadataDto } from '../../api/password.api.ts';
+import type {
+	CiphertextPhase,
+	PasswordFormState,
+	SavePasswordResult,
+} from './index.ts';
+import RippleButton from '../layout/RippleButton.tsx';
+import PasswordListItemFrame from './PasswordListItemFrame.tsx';
+
+type SshKeyListItemProps = {
+	passwordDto: PasswordMetadataDto;
+	setPasswordDto: React.Dispatch<React.SetStateAction<PasswordMetadataDto[]>>;
+	phase?: CiphertextPhase;
+	isSubmitting: boolean;
+	isVaultOnline: boolean;
+	onSave: (
+		formState: PasswordFormState,
+		passwordId?: string
+	) => Promise<SavePasswordResult>;
+	onDelete: (passwordId: string) => void;
+	onDownloadSshKey: (password: PasswordMetadataDto) => void;
+};
+
+function SshKeyListItem({
+	passwordDto,
+	setPasswordDto,
+	phase,
+	isSubmitting,
+	isVaultOnline,
+	onSave,
+	onDelete,
+	onDownloadSshKey,
+}: SshKeyListItemProps) {
+	return (
+		<PasswordListItemFrame
+			passwordDto={passwordDto}
+			setPasswordDto={setPasswordDto}
+			isSubmitting={isSubmitting}
+			isVaultOnline={isVaultOnline}
+			onSave={onSave}
+			onDelete={onDelete}
+			icon={<MdVpnKey size={14} />}
+			iconLabel="SSH key"
+			editInitialState={{
+				identifier: passwordDto.identifier,
+				address: passwordDto.address,
+				privateKey: '',
+				publicKey: '',
+				passwordType: 'SSH_KEY',
+			}}
+		>
+			<div className="flex items-center justify-between gap-3 rounded bg-gray-50 p-2">
+				<p className="max-w-full overflow-x-auto whitespace-nowrap font-mono text-sm text-gray-700">
+					SSH key file
+				</p>
+
+				<RippleButton
+					type="button"
+					variant="outline"
+					className="inline-flex items-center gap-1 rounded-sm border px-2 py-1 text-sm"
+					disabled={phase !== undefined}
+					rippleColor="rgb(0, 0, 0, 0.7)"
+					onClick={() => onDownloadSshKey(passwordDto)}
+				>
+					<MdDownload size={16} />
+					{phase !== undefined ? `${phase}...` : 'Download keys'}
+				</RippleButton>
+			</div>
+		</PasswordListItemFrame>
+	);
+}
+
+export default SshKeyListItem;

--- a/mossy-frontend/src/ui/passwords/index.ts
+++ b/mossy-frontend/src/ui/passwords/index.ts
@@ -1,12 +1,21 @@
 import type { PasswordType } from '../../api/password.api.ts';
 
 export type CiphertextPhase = 'Fetching' | 'Decrypting';
-export type PasswordFormState = {
+type PasswordBaseFormState = {
 	identifier: string;
 	address: string;
-	password: string;
 	passwordType: PasswordType;
 };
+export type PasswordFormState =
+	| (PasswordBaseFormState & {
+			passwordType: 'PASSWORD';
+			password: string;
+	  })
+	| (PasswordBaseFormState & {
+			passwordType: 'SSH_KEY';
+			privateKey: string;
+			publicKey: string;
+	  });
 export type SavePasswordResult = 'saved' | 'deferred' | 'failed';
 export type StatusMessage =
 	| { type: 'success'; message: string }

--- a/mossy-frontend/src/ui/passwords/index.ts
+++ b/mossy-frontend/src/ui/passwords/index.ts
@@ -14,7 +14,7 @@ export type PasswordFormState =
 	| (PasswordBaseFormState & {
 			passwordType: 'SSH_KEY';
 			privateKey: string;
-			publicKey: string;
+			publicKey?: string;
 	  });
 export type SavePasswordResult = 'saved' | 'deferred' | 'failed';
 export type StatusMessage =

--- a/mossy-frontend/src/ui/passwords/secretPayload.ts
+++ b/mossy-frontend/src/ui/passwords/secretPayload.ts
@@ -8,7 +8,7 @@ export type PasswordSecretPayload = {
 export type SshSecretPayload = {
 	kind: 'SSH';
 	privateKey: string;
-	publicKey: string;
+	publicKey?: string;
 };
 
 export type SecretPayload = PasswordSecretPayload | SshSecretPayload;
@@ -23,9 +23,9 @@ function asObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null;
 }
 
-export function validateSshKeyPair(privateKey: string, publicKey: string) {
+export function validateSshKeyPair(privateKey: string, publicKey?: string) {
 	const trimmedPrivateKey = privateKey.trim();
-	const trimmedPublicKey = publicKey.trim();
+	const trimmedPublicKey = publicKey?.trim();
 
 	if (!trimmedPrivateKey) {
 		return 'Private SSH key is required.';
@@ -35,11 +35,7 @@ export function validateSshKeyPair(privateKey: string, publicKey: string) {
 		return 'Private SSH key must be an OpenSSH or PEM private key.';
 	}
 
-	if (!trimmedPublicKey) {
-		return 'Public SSH key is required.';
-	}
-
-	if (!PUBLIC_KEY_PATTERN.test(trimmedPublicKey)) {
+	if (trimmedPublicKey && !PUBLIC_KEY_PATTERN.test(trimmedPublicKey)) {
 		return 'Public SSH key must be an OpenSSH public key.';
 	}
 
@@ -60,7 +56,7 @@ export function toSecretPayload(formState: PasswordFormState): SecretPayload {
 		return {
 			kind: 'SSH',
 			privateKey: formState.privateKey.trim(),
-			publicKey: formState.publicKey.trim(),
+			publicKey: formState.publicKey?.trim(),
 		};
 	}
 
@@ -74,9 +70,7 @@ export function serializeSecretPayload(formState: PasswordFormState) {
 	return JSON.stringify(toSecretPayload(formState));
 }
 
-export function parseSecretPayload(
-	decrypted: string
-): SecretPayload {
+export function parseSecretPayload(decrypted: string): SecretPayload {
 	const parsed: unknown = JSON.parse(decrypted);
 
 	if (

--- a/mossy-frontend/src/ui/passwords/secretPayload.ts
+++ b/mossy-frontend/src/ui/passwords/secretPayload.ts
@@ -1,0 +1,107 @@
+import type { PasswordFormState } from './index.ts';
+
+export type PasswordSecretPayload = {
+	kind: 'PASSWORD';
+	password: string;
+};
+
+export type SshSecretPayload = {
+	kind: 'SSH';
+	privateKey: string;
+	publicKey: string;
+};
+
+export type SecretPayload = PasswordSecretPayload | SshSecretPayload;
+
+const PRIVATE_KEY_PATTERN =
+	/-----BEGIN (OPENSSH|RSA|DSA|EC|ENCRYPTED|) ?PRIVATE KEY-----[\s\S]+-----END \1 ?PRIVATE KEY-----/;
+
+const PUBLIC_KEY_PATTERN =
+	/^(ssh-(rsa|ed25519)|ecdsa-sha2-nistp(256|384|521)|sk-ssh-ed25519@openssh\.com|sk-ecdsa-sha2-nistp256@openssh\.com) [A-Za-z0-9+/]+={0,3}( .*)?$/;
+
+function asObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+export function validateSshKeyPair(privateKey: string, publicKey: string) {
+	const trimmedPrivateKey = privateKey.trim();
+	const trimmedPublicKey = publicKey.trim();
+
+	if (!trimmedPrivateKey) {
+		return 'Private SSH key is required.';
+	}
+
+	if (!PRIVATE_KEY_PATTERN.test(trimmedPrivateKey)) {
+		return 'Private SSH key must be an OpenSSH or PEM private key.';
+	}
+
+	if (!trimmedPublicKey) {
+		return 'Public SSH key is required.';
+	}
+
+	if (!PUBLIC_KEY_PATTERN.test(trimmedPublicKey)) {
+		return 'Public SSH key must be an OpenSSH public key.';
+	}
+
+	return null;
+}
+
+export function toSecretPayload(formState: PasswordFormState): SecretPayload {
+	if (formState.passwordType === 'SSH_KEY') {
+		const validationMessage = validateSshKeyPair(
+			formState.privateKey,
+			formState.publicKey
+		);
+
+		if (validationMessage) {
+			throw new Error(validationMessage);
+		}
+
+		return {
+			kind: 'SSH',
+			privateKey: formState.privateKey.trim(),
+			publicKey: formState.publicKey.trim(),
+		};
+	}
+
+	return {
+		kind: 'PASSWORD',
+		password: formState.password,
+	};
+}
+
+export function serializeSecretPayload(formState: PasswordFormState) {
+	return JSON.stringify(toSecretPayload(formState));
+}
+
+export function parseSecretPayload(
+	decrypted: string
+): SecretPayload {
+	const parsed: unknown = JSON.parse(decrypted);
+
+	if (
+		asObject(parsed) &&
+		parsed.kind === 'PASSWORD' &&
+		typeof parsed.password === 'string'
+	) {
+		return {
+			kind: 'PASSWORD',
+			password: parsed.password,
+		};
+	}
+
+	if (
+		asObject(parsed) &&
+		parsed.kind === 'SSH' &&
+		typeof parsed.privateKey === 'string' &&
+		typeof parsed.publicKey === 'string'
+	) {
+		return {
+			kind: 'SSH',
+			privateKey: parsed.privateKey,
+			publicKey: parsed.publicKey,
+		};
+	}
+
+	throw new Error('Unsupported secret payload format');
+}

--- a/mossy-frontend/src/ui/passwords/sshKeyDownload.ts
+++ b/mossy-frontend/src/ui/passwords/sshKeyDownload.ts
@@ -1,0 +1,37 @@
+import type { PasswordMetadataDto } from '../../api/password.api.ts';
+
+export function getSshKeyFilename(
+	password: PasswordMetadataDto,
+	keyType: 'private' | 'public'
+) {
+	const fallback = password.passwordId;
+	const rawName = password.identifier || password.address || fallback;
+	const safeName =
+		rawName
+			.trim()
+			.replace(/[^a-zA-Z0-9._-]+/g, '-')
+			.replace(/^-+|-+$/g, '') || fallback;
+
+	if (keyType === 'public') {
+		return safeName.endsWith('.pub') ? safeName : `${safeName}.pub`;
+	}
+
+	return safeName.endsWith('.key') || safeName.endsWith('.pem')
+		? safeName
+		: `${safeName}.key`;
+}
+
+export function downloadTextFile(filename: string, content: string) {
+	const url = URL.createObjectURL(
+		new Blob([content], { type: 'application/octet-stream' })
+	);
+	const link = document.createElement('a');
+
+	link.href = url;
+	link.download = filename;
+	link.style.display = 'none';
+	document.body.appendChild(link);
+	link.click();
+	link.remove();
+	URL.revokeObjectURL(url);
+}

--- a/mossy-frontend/src/ui/passwords/usePasswordListActions.tsx
+++ b/mossy-frontend/src/ui/passwords/usePasswordListActions.tsx
@@ -1,0 +1,358 @@
+import { useEffect, useState } from 'react';
+import {
+	executeDeletePasswordRequest,
+	executePasswordCiphertextRequest,
+	executeSavePasswordRequest,
+	executeUpdatePasswordRequest,
+	type PasswordMetadataDto,
+	type ServerResponseDto,
+} from '../../api/password.api.ts';
+import type {
+	CiphertextPhase,
+	PasswordFormState,
+	SavePasswordResult,
+	StatusMessage,
+} from './index.ts';
+import { useEncryptionHook } from '../../hooks/useEncryptionHook.ts';
+import { KeyNotFoundException } from '../../exception/KeyNotFoundException.ts';
+import PasswordPinModal from '../shared/PasswordPinModal.tsx';
+import KeySyncModal from './KeySyncModal.tsx';
+import { parseSecretPayload, serializeSecretPayload } from './secretPayload.ts';
+import { downloadTextFile, getSshKeyFilename } from './sshKeyDownload.ts';
+
+type UsePasswordListActionsOptions = {
+	vaultId: string;
+	isVaultOnline: boolean;
+	refreshVaults: () => Promise<void>;
+};
+
+type SavePasswordOptions = {
+	onSaved?: () => void;
+};
+
+export function usePasswordListActions({
+	vaultId,
+	isVaultOnline,
+	refreshVaults,
+}: UsePasswordListActionsOptions) {
+	const { encrypt, decrypt, isPinPresent } = useEncryptionHook();
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [status, setStatus] = useState<StatusMessage>(null);
+	const [refreshToken, setRefreshToken] = useState(0);
+	const [revealedPasswords, setRevealedPasswords] = useState<
+		Record<string, string>
+	>({});
+	const [loadingCiphertextPhase, setLoadingCiphertextPhase] = useState<
+		Record<string, CiphertextPhase>
+	>({});
+	const [isPinModalActive, setIsPinModalActive] = useState(false);
+	const [isKeySyncModalActive, setIsKeySyncModalActive] = useState(false);
+	const [lastAction, setLastAction] = useState<
+		((pin: string) => void) | undefined
+	>();
+
+	useEffect(() => {
+		setStatus(null);
+		setRevealedPasswords({});
+		setLoadingCiphertextPhase({});
+	}, [vaultId]);
+
+	useEffect(() => {
+		const bc = new BroadcastChannel('vault_updates');
+
+		bc.onmessage = (event) => {
+			if (event.data !== 'refresh' || !vaultId || !isVaultOnline) return;
+			setRefreshToken((prev) => prev + 1);
+		};
+
+		return () => bc.close();
+	}, [vaultId, isVaultOnline]);
+
+	const runWithVaultKeySync = async <T,>(
+		action: () => Promise<T>
+	): Promise<
+		| {
+				type: 'completed';
+				value: T;
+		  }
+		| { type: 'deferred' }
+	> => {
+		try {
+			if (!(await isPinPresent(vaultId))) {
+				setLastAction(() => () => {
+					void action();
+				});
+				setIsPinModalActive(true);
+				return { type: 'deferred' };
+			}
+		} catch (error) {
+			if (error instanceof KeyNotFoundException) {
+				setLastAction(() => () => {
+					void action();
+				});
+				setIsKeySyncModalActive(true);
+				return { type: 'deferred' };
+			}
+			throw error;
+		}
+
+		return { type: 'completed', value: await action() };
+	};
+
+	const resumeSavePassword = async (
+		formState: PasswordFormState,
+		passwordId?: string,
+		options?: SavePasswordOptions
+	): Promise<SavePasswordResult> => {
+		setIsSubmitting(true);
+		setStatus(null);
+
+		try {
+			const basePayload = {
+				identifier: formState.identifier,
+				address: formState.address,
+				cipherText: await encrypt(
+					serializeSecretPayload(formState),
+					vaultId
+				),
+				vaultId,
+			};
+
+			const response: ServerResponseDto = passwordId
+				? await executeUpdatePasswordRequest({
+						...basePayload,
+						passwordId,
+					})
+				: await executeSavePasswordRequest({
+						...basePayload,
+						passwordType: formState.passwordType,
+					});
+
+			setStatus({ type: 'success', message: response.message });
+			await refreshVaults();
+			setRefreshToken((prev) => prev + 1);
+			options?.onSaved?.();
+			return 'saved';
+		} catch (error) {
+			setStatus({
+				type: 'error',
+				message:
+					error instanceof Error
+						? error.message
+						: 'Failed to save password data',
+			});
+			return 'failed';
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const handleSavePassword = async (
+		formState: PasswordFormState,
+		passwordId?: string,
+		options?: SavePasswordOptions
+	): Promise<SavePasswordResult> => {
+		if (!vaultId || !isVaultOnline) {
+			setStatus({
+				type: 'error',
+				message: 'Select an online vault to save password',
+			});
+			return 'failed';
+		}
+
+		try {
+			const result = await runWithVaultKeySync(() =>
+				resumeSavePassword(formState, passwordId, options)
+			);
+
+			return result.type === 'deferred' ? 'deferred' : result.value;
+		} catch (error) {
+			setStatus({
+				type: 'error',
+				message:
+					error instanceof Error
+						? error.message
+						: 'Failed to save password data',
+			});
+			return 'failed';
+		}
+	};
+
+	const handleDelete = async (passwordId: string) => {
+		if (!vaultId || !isVaultOnline) return;
+
+		setIsSubmitting(true);
+		setStatus(null);
+
+		try {
+			const response = await executeDeletePasswordRequest({
+				passwordId,
+				vaultId,
+			});
+
+			setStatus({ type: 'success', message: response.message });
+			await refreshVaults();
+			setRefreshToken((prev) => prev + 1);
+		} catch (error) {
+			setStatus({
+				type: 'error',
+				message:
+					error instanceof Error
+						? error.message
+						: 'Failed to delete password',
+			});
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const resumeRevealToggle = async (passwordId: string) => {
+		if (revealedPasswords[passwordId]) {
+			setRevealedPasswords((prev) => {
+				const next = { ...prev };
+				delete next[passwordId];
+				return next;
+			});
+			return;
+		}
+
+		setLoadingCiphertextPhase((prev) => ({
+			...prev,
+			[passwordId]: 'Fetching',
+		}));
+		setStatus(null);
+
+		try {
+			const response = await executePasswordCiphertextRequest(
+				passwordId,
+				vaultId
+			);
+
+			setLoadingCiphertextPhase((prev) => ({
+				...prev,
+				[passwordId]: 'Decrypting',
+			}));
+
+			const decrypted = await decrypt(response.ciphertext, vaultId);
+			const secretPayload = parseSecretPayload(decrypted);
+
+			if (secretPayload.kind !== 'PASSWORD') {
+				throw new Error('Selected entry does not contain a password.');
+			}
+
+			setRevealedPasswords((prev) => ({
+				...prev,
+				[passwordId]: secretPayload.password,
+			}));
+		} catch (error) {
+			setStatus({
+				type: 'error',
+				message:
+					error instanceof Error
+						? error.message
+						: 'Failed to reveal password',
+			});
+		} finally {
+			setLoadingCiphertextPhase((prev) => {
+				const next = { ...prev };
+				delete next[passwordId];
+				return next;
+			});
+		}
+	};
+
+	const handleRevealToggle = async (passwordId: string) => {
+		if (!vaultId || !isVaultOnline) return;
+
+		await runWithVaultKeySync(() => resumeRevealToggle(passwordId));
+	};
+
+	const resumeDownloadSshKey = async (password: PasswordMetadataDto) => {
+		setLoadingCiphertextPhase((prev) => ({
+			...prev,
+			[password.passwordId]: 'Fetching',
+		}));
+		setStatus(null);
+
+		try {
+			const response = await executePasswordCiphertextRequest(
+				password.passwordId,
+				vaultId
+			);
+
+			setLoadingCiphertextPhase((prev) => ({
+				...prev,
+				[password.passwordId]: 'Decrypting',
+			}));
+
+			const decrypted = await decrypt(response.ciphertext, vaultId);
+			const secretPayload = parseSecretPayload(decrypted);
+
+			if (secretPayload.kind !== 'SSH') {
+				throw new Error('Selected entry does not contain SSH keys.');
+			}
+
+			downloadTextFile(
+				getSshKeyFilename(password, 'private'),
+				secretPayload.privateKey
+			);
+
+			if (secretPayload.publicKey) {
+				downloadTextFile(
+					getSshKeyFilename(password, 'public'),
+					secretPayload.publicKey
+				);
+			}
+		} catch (error) {
+			setStatus({
+				type: 'error',
+				message:
+					error instanceof Error
+						? error.message
+						: 'Failed to download SSH key',
+			});
+		} finally {
+			setLoadingCiphertextPhase((prev) => {
+				const next = { ...prev };
+				delete next[password.passwordId];
+				return next;
+			});
+		}
+	};
+
+	const handleDownloadSshKey = async (password: PasswordMetadataDto) => {
+		if (!vaultId || !isVaultOnline) return;
+
+		await runWithVaultKeySync(() => resumeDownloadSshKey(password));
+	};
+
+	return {
+		isSubmitting,
+		status,
+		refreshToken,
+		revealedPasswords,
+		loadingCiphertextPhase,
+		handleSavePassword,
+		handleDelete,
+		handleRevealToggle,
+		handleDownloadSshKey,
+		actionModals: (
+			<>
+				{isPinModalActive && (
+					<PasswordPinModal
+						vaultId={vaultId}
+						setIsPinModalActive={setIsPinModalActive}
+						afterPinEntered={lastAction}
+					/>
+				)}
+
+				{isKeySyncModalActive && (
+					<KeySyncModal
+						setIsKeySyncModalActive={setIsKeySyncModalActive}
+						vaultId={vaultId}
+					/>
+				)}
+			</>
+		),
+	};
+}

--- a/self-hosted/mossy-vault/src/main/kotlin/pl/dayfit/mossyvault/messaging/consumer/AssignTagHandler.kt
+++ b/self-hosted/mossy-vault/src/main/kotlin/pl/dayfit/mossyvault/messaging/consumer/AssignTagHandler.kt
@@ -37,20 +37,22 @@ class AssignTagHandler(
                 return
             }
 
-        val passwordEntry = passwordEntryRepository.findById(payload.passwordId)
-            .getOrElse {
+        val passwordEntry = passwordEntryRepository.findWithTagsById(payload.passwordId)
+            ?: run {
                 stompSessionRegistry.send(
                     StompEndpoints.USER_TAG_ASSIGNED,
                     VaultResponseMessageDto(
                         message.messageId,
                         AssignTagResponseType(),
                         VaultResponseStatus.NOT_FOUND
-                    ))
+                    )
+                )
                 return
             }
 
-        passwordEntry.tags
-            .add(tag)
+        if (passwordEntry.tags.none { it.id == tag.id }) {
+            passwordEntry.tags.add(tag)
+        }
 
         passwordEntryRepository.save(passwordEntry)
 

--- a/self-hosted/mossy-vault/src/main/kotlin/pl/dayfit/mossyvault/messaging/consumer/UnassignTagHandler.kt
+++ b/self-hosted/mossy-vault/src/main/kotlin/pl/dayfit/mossyvault/messaging/consumer/UnassignTagHandler.kt
@@ -39,20 +39,20 @@ class UnassignTagHandler(
                 return
             }
 
-        val passwordEntry = passwordEntryRepository.findById(payload.passwordId)
-            .getOrElse {
+        val passwordEntry = passwordEntryRepository.findWithTagsById(payload.passwordId)
+            ?: run {
                 stompSessionRegistry.send(
                     StompEndpoints.USER_TAG_UNASSIGNED,
                     VaultResponseMessageDto(
                         messageId,
                         UnassignTagResponseType(),
                         VaultResponseStatus.NOT_FOUND
-                    ))
+                    )
+                )
                 return
             }
 
-        passwordEntry.tags
-            .remove(tag)
+        passwordEntry.tags.removeIf { it.id == tag.id }
 
         passwordEntryRepository.save(passwordEntry)
 
@@ -70,4 +70,3 @@ class UnassignTagHandler(
         return StompEndpoints.SUBSCRIBE_UNASSIGN_TAG
     }
 }
-

--- a/self-hosted/mossy-vault/src/main/kotlin/pl/dayfit/mossyvault/repository/PasswordEntryRepository.kt
+++ b/self-hosted/mossy-vault/src/main/kotlin/pl/dayfit/mossyvault/repository/PasswordEntryRepository.kt
@@ -10,5 +10,6 @@ import java.util.UUID
 interface PasswordEntryRepository : JpaRepository<PasswordEntry, UUID> {
     @EntityGraph(attributePaths = ["tags"])
     fun findAllBy(): List<PasswordEntry>
-    fun findFirstByAddressAndIdentifier(address: String, identifier: String): PasswordEntry?
+    @EntityGraph(attributePaths = ["tags"])
+    fun findWithTagsById(id: UUID): PasswordEntry?
 }


### PR DESCRIPTION
This pull request significantly refactors the password management UI, focusing on modularizing state management, improving SSH key handling, and simplifying the main `PasswordHero` component. The changes introduce a new hook for password list actions, extract SSH key logic into dedicated components, and streamline props and state across the password-related components.

**Major improvements:**

*Theming: SSH Key Handling*
- Extracted SSH key input logic from `PasswordEntryInput` into a new `SshKeyEntryInput` component, improving separation of concerns and maintainability. Validation for SSH key pairs is now handled before submission, with clear error feedback. [[1]](diffhunk://#diff-118b84b8a0ddff5100b7b6d5c19a93a522a944848905148456805f5e5ec8c219L1-R8) [[2]](diffhunk://#diff-118b84b8a0ddff5100b7b6d5c19a93a522a944848905148456805f5e5ec8c219L51-R92) [[3]](diffhunk://#diff-118b84b8a0ddff5100b7b6d5c19a93a522a944848905148456805f5e5ec8c219L100-R115) [[4]](diffhunk://#diff-118b84b8a0ddff5100b7b6d5c19a93a522a944848905148456805f5e5ec8c219L203-R246)
- Added a new `SshKeyListItem` component for displaying SSH key entries in the password list, ensuring SSH keys are handled distinctly from regular passwords. [[1]](diffhunk://#diff-6ae79d4aeae82c6e2f186984480c2597c123773cf0b24c5e2786f8d0b604aa4bL5-R43) [[2]](diffhunk://#diff-6ae79d4aeae82c6e2f186984480c2597c123773cf0b24c5e2786f8d0b604aa4bL164-R208)

*State Management & Logic Extraction*
- Moved all password list actions (save, delete, reveal, download SSH key, modals) into a new `usePasswordListActions` hook, removing large amounts of state and logic from `PasswordHero` and `PasswordListCard`. This makes the codebase more modular and easier to test and maintain. [[1]](diffhunk://#diff-6ae79d4aeae82c6e2f186984480c2597c123773cf0b24c5e2786f8d0b604aa4bL5-R43) [[2]](diffhunk://#diff-6ae79d4aeae82c6e2f186984480c2597c123773cf0b24c5e2786f8d0b604aa4bR105-R106)
- Updated `PasswordListCard` to use the new hook, simplifying its props and internal state. Now, it receives only necessary props and delegates all actions to the hook. [[1]](diffhunk://#diff-6ae79d4aeae82c6e2f186984480c2597c123773cf0b24c5e2786f8d0b604aa4bL5-R43) [[2]](diffhunk://#diff-6ae79d4aeae82c6e2f186984480c2597c123773cf0b24c5e2786f8d0b604aa4bR57-R60) [[3]](diffhunk://#diff-6ae79d4aeae82c6e2f186984480c2597c123773cf0b24c5e2786f8d0b604aa4bR105-R106) [[4]](diffhunk://#diff-6ae79d4aeae82c6e2f186984480c2597c123773cf0b24c5e2786f8d0b604aa4bL155-R158)

*Component Simplification*
- Greatly simplified `PasswordHero` by removing all password management logic and state, focusing it solely on vault selection and layout. All password-related actions are now handled in child components or hooks. [[1]](diffhunk://#diff-fd09620b8b3ca69a497eabfa2134fa6588dbec534c2133477d48b113bfc7cc9aL1-L384) [[2]](diffhunk://#diff-fd09620b8b3ca69a497eabfa2134fa6588dbec534c2133477d48b113bfc7cc9aL412-R62)

*Other Minor Improvements*
- Added `.idea/copilotDiffState.xml` to `.gitignore` to avoid committing IDE-specific state files.

These changes collectively make the password management UI more maintainable, modular, and easier to extend for future features.