### PR TITLE
refactor: Remove 'jwks' service from Docker build matrix

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         service:
           - device
-          - jwks
           - password
           - statistics
           - auth


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/build-docker.yml` file by removing the `jwks` service from the build matrix. This means the `jwks` service will no longer be included in the Docker build workflow.